### PR TITLE
Fix removal option TrustedMACList

### DIFF
--- a/wifidog.conf
+++ b/wifidog.conf
@@ -200,6 +200,15 @@ ClientTimeout 5
 #
 # SSLCertPath /etc/ssl/certs/ 
 
+# Parameter: TrustedMACList
+# Default: none
+# Optional
+#
+# Comma separated list of MAC addresses who are allowed to pass
+# through without authentication.
+# N.B.: weak security, since MAC addresses are easy to spoof.
+#
+#TrustedMACList 00:00:DE:AD:BE:AF,00:00:C0:1D:F0:0D
 
 # Parameter: FirewallRuleSet
 # Default: none


### PR DESCRIPTION
Certainly a mistake among all the recent corrections.

TrustedMACList Isn't deprecated.
